### PR TITLE
feat: resume solowallet transaction

### DIFF
--- a/apps/api/src/solowallet/solowallet.controller.ts
+++ b/apps/api/src/solowallet/solowallet.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ContinueTxRequestDto,
   DepositFundsRequestDto,
   UpdateTxDto,
   UserTxsRequestDto,
@@ -50,5 +51,14 @@ export class SolowalletController {
   })
   updateShares(@Body() req: UpdateTxDto) {
     return this.walletService.updateTransaction(req);
+  }
+
+  @Post('continue')
+  @ApiOperation({ summary: 'Continue Solowallet transaction' })
+  @ApiBody({
+    type: ContinueTxRequestDto,
+  })
+  continueTransaction(@Body() req: ContinueTxRequestDto) {
+    return this.walletService.continueTransaction(req);
   }
 }

--- a/apps/api/src/solowallet/solowallet.service.ts
+++ b/apps/api/src/solowallet/solowallet.service.ts
@@ -5,6 +5,7 @@ import {
   SolowalletServiceClient,
   WithdrawFundsRequestDto,
   UpdateTxDto,
+  ContinueTxRequestDto,
 } from '@bitsacco/common';
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { type ClientGrpc } from '@nestjs/microservices';
@@ -37,5 +38,9 @@ export class SolowalletService implements OnModuleInit {
 
   updateTransaction(req: UpdateTxDto) {
     return this.client.updateTransaction(req);
+  }
+
+  continueTransaction(req: ContinueTxRequestDto) {
+    return this.client.continueTransaction(req);
   }
 }

--- a/apps/solowallet/src/solowallet.controller.ts
+++ b/apps/solowallet/src/solowallet.controller.ts
@@ -6,6 +6,7 @@ import {
   UserTxsRequestDto,
   WithdrawFundsRequestDto,
   UpdateTxDto,
+  ContinueTxRequestDto,
 } from '@bitsacco/common';
 import { SolowalletService } from './solowallet.service';
 
@@ -32,5 +33,10 @@ export class SolowalletController {
   @GrpcMethod()
   updateTransaction(request: UpdateTxDto) {
     return this.solowalletService.updateTransaction(request);
+  }
+
+  @GrpcMethod()
+  continueTransaction(request: ContinueTxRequestDto) {
+    return this.solowalletService.continueTransaction(request);
   }
 }

--- a/libs/common/src/database/abstract.repository.ts
+++ b/libs/common/src/database/abstract.repository.ts
@@ -3,7 +3,6 @@ import {
   Model,
   PipelineStage,
   SortOrder,
-  Types,
   UpdateQuery,
 } from 'mongoose';
 import { Logger, NotFoundException } from '@nestjs/common';

--- a/libs/common/src/dto/solowallet.dto.ts
+++ b/libs/common/src/dto/solowallet.dto.ts
@@ -22,6 +22,7 @@ import {
   UpdateTxRequest,
   SolowalletTxUpdates,
   TransactionStatus,
+  ContinueTxRequest,
 } from '../types';
 import { PaginatedRequestDto } from './lib.dto';
 
@@ -124,4 +125,29 @@ export class UpdateTxDto implements UpdateTxRequest {
   @Type(() => SolowalletTxUpdatesDto)
   @ApiProperty({ type: SolowalletTxUpdatesDto })
   updates: SolowalletTxUpdatesDto;
+}
+
+export class ContinueTxRequestDto implements ContinueTxRequest {
+  @IsNotEmpty()
+  @IsString()
+  @Type(() => String)
+  @ApiProperty({ example: '7b158dfd-cb98-40b1-9ed2-a13006a9f670' })
+  userId: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Type(() => String)
+  @ApiProperty({ example: '35f47ebd-599e-4334-a741-67f3495995e3' })
+  txId: string;
+
+  @ApiProperty()
+  @IsNumber()
+  @Min(1)
+  @ApiProperty({ example: 2 })
+  amountFiat: number;
+
+  @ValidateNested()
+  @Type(() => OnrampSwapSourceDto)
+  @ApiProperty({ type: OnrampSwapSourceDto })
+  onramp?: OnrampSwapSourceDto;
 }

--- a/libs/common/src/types/proto/solowallet.ts
+++ b/libs/common/src/types/proto/solowallet.ts
@@ -85,6 +85,13 @@ export interface SolowalletTxUpdates {
   reference?: string | undefined;
 }
 
+export interface ContinueTxRequest {
+  userId: string;
+  txId: string;
+  amountFiat: number;
+  onramp?: OnrampSwapSource | undefined;
+}
+
 export interface SolowalletServiceClient {
   depositFunds(request: DepositFundsRequest): Observable<UserTxsResponse>;
 
@@ -93,6 +100,8 @@ export interface SolowalletServiceClient {
   userTransactions(request: UserTxsRequest): Observable<UserTxsResponse>;
 
   updateTransaction(request: UpdateTxRequest): Observable<UserTxsResponse>;
+
+  continueTransaction(request: ContinueTxRequest): Observable<UserTxsResponse>;
 }
 
 export interface SolowalletServiceController {
@@ -111,6 +120,10 @@ export interface SolowalletServiceController {
   updateTransaction(
     request: UpdateTxRequest,
   ): Promise<UserTxsResponse> | Observable<UserTxsResponse> | UserTxsResponse;
+
+  continueTransaction(
+    request: ContinueTxRequest,
+  ): Promise<UserTxsResponse> | Observable<UserTxsResponse> | UserTxsResponse;
 }
 
 export function SolowalletServiceControllerMethods() {
@@ -120,6 +133,7 @@ export function SolowalletServiceControllerMethods() {
       'withdrawFunds',
       'userTransactions',
       'updateTransaction',
+      'continueTransaction',
     ];
     for (const method of grpcMethods) {
       const descriptor: any = Reflect.getOwnPropertyDescriptor(

--- a/proto/solowallet.proto
+++ b/proto/solowallet.proto
@@ -14,6 +14,8 @@ service SolowalletService {
   rpc UserTransactions(UserTxsRequest) returns (UserTxsResponse){}
 
   rpc UpdateTransaction(UpdateTxRequest) returns (UserTxsResponse) {}
+
+  rpc ContinueTransaction(ContinueTxRequest) returns (UserTxsResponse) {}
 }
 
 message DepositFundsRequest {
@@ -109,4 +111,14 @@ message SolowalletTxUpdates {
   optional lib.TransactionStatus status = 1;
   optional lightning.Bolt11 lightning = 2;
   optional string reference = 3;
+}
+
+message ContinueTxRequest {
+  string user_id = 1;
+
+  string tx_id = 2;
+
+  int32 amount_fiat = 3;
+
+  optional swap.OnrampSwapSource onramp = 5;
 }


### PR DESCRIPTION
pay to complete an existing solowallet transaction
- refreshes exchange rate to current
- retriggers stk push
- refreshes target ln invoice