### PR TITLE
feat: support both cookie and bearer auth

### DIFF
--- a/apps/api/src/chamas/chamas.controller.ts
+++ b/apps/api/src/chamas/chamas.controller.ts
@@ -29,8 +29,9 @@ import {
 } from '@nestjs/common';
 import { type ClientGrpc } from '@nestjs/microservices';
 import {
-  ApiBearerAuth,
   ApiBody,
+  ApiBearerAuth,
+  ApiCookieAuth,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -57,6 +58,7 @@ export class ChamasController {
 
   @Post('create')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Create new Chama' })
   @ApiBody({
     type: CreateChamaDto,
@@ -67,6 +69,7 @@ export class ChamasController {
 
   @Patch('update')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Update existing Chama' })
   @ApiBody({
     type: UpdateChamaDto,
@@ -77,6 +80,7 @@ export class ChamasController {
 
   @Post('join')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Join existing Chama' })
   @ApiBody({
     type: JoinChamaDto,
@@ -87,6 +91,7 @@ export class ChamasController {
 
   @Post('invite')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Invite members to existing Chama' })
   @ApiBody({
     type: InviteMembersDto,
@@ -97,6 +102,7 @@ export class ChamasController {
 
   @Get('find/:chamaId')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Find existing Chama by ID' })
   @ApiParam({ name: 'chamaId', description: 'Chama ID' })
   async findChama(@Param('chamaId') chamaId: string) {
@@ -105,6 +111,7 @@ export class ChamasController {
 
   @Get('filter/')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Filter existing Chamas by queries' })
   @ApiQuery({
     name: 'memberId',
@@ -130,6 +137,7 @@ export class ChamasController {
 
   @Post('tx/deposit')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Chama deposit transaction' })
   @ApiBody({
     type: ChamaDepositDto,
@@ -140,6 +148,7 @@ export class ChamasController {
 
   @Post('tx/deposit/continue')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Continue Chama deposit transaction' })
   @ApiBody({
     type: ChamaContinueDepositDto,
@@ -150,6 +159,7 @@ export class ChamasController {
 
   @Post('tx/withdraw')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Chama withdrawal transaction' })
   @ApiBody({
     type: ChamaWithdrawDto,
@@ -160,6 +170,7 @@ export class ChamasController {
 
   @Post('tx/withdraw/continue')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Continue Chama withdrawal transaction' })
   @ApiBody({
     type: ChamaContinueWithdrawDto,
@@ -170,6 +181,7 @@ export class ChamasController {
 
   @Patch('tx/update')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Update Chama transaction' })
   @ApiBody({
     type: UpdateChamaTransactionDto,
@@ -180,6 +192,7 @@ export class ChamasController {
 
   @Get('tx/find/:txId')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Find Chama transaction by ID' })
   @ApiParam({ name: 'txId', description: 'Transaction ID' })
   async findTransaction(@Param('txId') txId: string) {
@@ -188,6 +201,7 @@ export class ChamasController {
 
   @Get('tx/filter/')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Filter chama transactions' })
   @ApiQuery({
     name: 'memberId',
@@ -213,6 +227,7 @@ export class ChamasController {
 
   @Post('tx/aggregate/')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Aggregate chama transactions' })
   @ApiBody({
     type: AggregateChamaTransactionsDto,

--- a/apps/api/src/nostr/nostr.controller.ts
+++ b/apps/api/src/nostr/nostr.controller.ts
@@ -1,4 +1,9 @@
-import { ApiOperation, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiBody,
+  ApiBearerAuth,
+  ApiCookieAuth,
+} from '@nestjs/swagger';
 import {
   Body,
   Controller,
@@ -30,6 +35,7 @@ export class NostrController {
 
   @Post('relays')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Configure nostr relays' })
   @ApiBody({
     type: ConfigureNostrRelaysDto,
@@ -40,6 +46,7 @@ export class NostrController {
 
   @Post('dm')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Send encrypted nostr dm' })
   @ApiBody({
     type: SendEncryptedNostrDmDto,

--- a/apps/api/src/shares/shares.controller.ts
+++ b/apps/api/src/shares/shares.controller.ts
@@ -27,6 +27,7 @@ import {
   ApiParam,
   ApiQuery,
   ApiBearerAuth,
+  ApiCookieAuth,
 } from '@nestjs/swagger';
 import { type ClientGrpc } from '@nestjs/microservices';
 
@@ -44,6 +45,7 @@ export class SharesController {
 
   @Post('offer')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Offer Bitsacco shares' })
   @ApiBody({
     type: OfferSharesDto,
@@ -54,6 +56,7 @@ export class SharesController {
 
   @Get('offers')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'List all share offers' })
   getShareOffers() {
     return this.sharesService.getSharesOffers({});
@@ -61,6 +64,7 @@ export class SharesController {
 
   @Post('subscribe')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Subscribe Bitsacco shares' })
   @ApiBody({
     type: SubscribeSharesDto,
@@ -71,6 +75,7 @@ export class SharesController {
 
   @Post('transfer')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Transfer Bitsacco shares' })
   @ApiBody({
     type: TransferSharesDto,
@@ -81,6 +86,7 @@ export class SharesController {
 
   @Post('update')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Update Bitsacco shares' })
   @ApiBody({
     type: UpdateSharesDto,
@@ -91,6 +97,7 @@ export class SharesController {
 
   @Get('transactions')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'List all Bitsacco share transactions' })
   allSharesTransactions() {
     return this.sharesService.allSharesTransactions({});
@@ -98,6 +105,7 @@ export class SharesController {
 
   @Get('transactions/:userId')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({
     summary: 'List all Bitsacco share transactions for user with given ID',
   })
@@ -130,6 +138,7 @@ export class SharesController {
 
   @Get('transactions/find/:sharesId')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({
     summary: 'Find Bitsacco shares transaction with given ID',
   })

--- a/apps/api/src/sms/sms.controller.ts
+++ b/apps/api/src/sms/sms.controller.ts
@@ -1,4 +1,9 @@
-import { ApiOperation, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiBody,
+  ApiBearerAuth,
+  ApiCookieAuth,
+} from '@nestjs/swagger';
 import {
   Body,
   Controller,
@@ -29,6 +34,7 @@ export class SmsController {
 
   @Post('send-message')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Send a single sms' })
   @ApiBody({
     type: SendSmsDto,
@@ -39,6 +45,7 @@ export class SmsController {
 
   @Post('send-bulk-message')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Send multiple sms' })
   @ApiBody({
     type: SendBulkSmsDto,

--- a/apps/api/src/solowallet/solowallet.controller.ts
+++ b/apps/api/src/solowallet/solowallet.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiBody,
   ApiParam,
   ApiBearerAuth,
+  ApiCookieAuth,
 } from '@nestjs/swagger';
 import { type ClientGrpc } from '@nestjs/microservices';
 
@@ -44,6 +45,7 @@ export class SolowalletController {
 
   @Post('deposit')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Deposit funds to Solowallet' })
   @ApiBody({
     type: DepositFundsRequestDto,
@@ -54,6 +56,7 @@ export class SolowalletController {
 
   @Post('withdraw')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Withdraw funds from Solowallet' })
   @ApiBody({
     type: WithdrawFundsRequestDto,
@@ -64,6 +67,7 @@ export class SolowalletController {
 
   @Post('transactions')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Find Solowallet user transactions' })
   @ApiBody({
     type: UserTxsRequestDto,
@@ -74,6 +78,7 @@ export class SolowalletController {
 
   @Post('update')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Update Solowallet transaction' })
   @ApiBody({
     type: UpdateTxDto,
@@ -84,6 +89,7 @@ export class SolowalletController {
 
   @Post('continue')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Continue Solowallet transaction' })
   @ApiBody({
     type: ContinueTxRequestDto,
@@ -94,6 +100,7 @@ export class SolowalletController {
 
   @Get('/find/id/:id')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Get transaction by ID' })
   @ApiParam({ name: 'id', description: 'Transaction ID' })
   async findTransaction(@Param('id') id: string) {

--- a/apps/api/src/swap/swap.controller.ts
+++ b/apps/api/src/swap/swap.controller.ts
@@ -14,6 +14,7 @@ import { object } from 'joi';
 import { type ClientGrpc, ClientProxy } from '@nestjs/microservices';
 import {
   ApiBearerAuth,
+  ApiCookieAuth,
   ApiBody,
   ApiOperation,
   ApiParam,
@@ -75,6 +76,7 @@ export class SwapController {
   @Post('onramp')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Post onramp transaction' })
   @ApiBody({
     type: CreateOnrampSwapDto,
@@ -86,6 +88,7 @@ export class SwapController {
   @Get('onramp/find/:id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Find onramp transaction by ID' })
   @ApiParam({ name: 'id', type: String, description: 'Transaction ID' })
   findOnrampTransaction(@Param('id') id: string) {
@@ -95,6 +98,7 @@ export class SwapController {
   @Get('onramp/all')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'List onramp swaps' })
   @ApiQuery({
     name: 'page',
@@ -143,6 +147,7 @@ export class SwapController {
   @Post('offramp')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Post offramp transaction' })
   @ApiBody({
     type: CreateOfframpSwapDto,
@@ -154,6 +159,7 @@ export class SwapController {
   @Get('offramp/find/:id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Find offramp transaction by ID' })
   @ApiParam({ name: 'id', type: 'string', description: 'Transaction ID' })
   findOfframpTransaction(@Param('id') id: string) {
@@ -163,6 +169,7 @@ export class SwapController {
   @Get('offramp/all')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'List all offramp swaps' })
   @ApiQuery({
     name: 'page',

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiCookieAuth,
   ApiBody,
   ApiOperation,
   ApiParam,
@@ -30,6 +31,7 @@ export class UsersController {
 
   @Get('all')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'List all users' })
   async listUsers() {
     return this.usersService.listUsers();
@@ -37,6 +39,7 @@ export class UsersController {
 
   @Get('/find/id/:id')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Get user by ID' })
   @ApiParam({ name: 'id', description: 'User ID' })
   async findUserById(@Param('id') id: string) {
@@ -45,6 +48,7 @@ export class UsersController {
 
   @Get('/find/phone/:phone')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Get user by phone' })
   @ApiParam({ name: 'phone', description: 'User phone' })
   async findUserByPhone(@Param('phone') phone: string) {
@@ -53,6 +57,7 @@ export class UsersController {
 
   @Get('/find/npub/:npub')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Get user by npub' })
   @ApiParam({ name: 'npub', description: 'User npub' })
   async findUserByNpub(@Param('npub') npub: string) {
@@ -61,6 +66,7 @@ export class UsersController {
 
   @Patch('/update')
   @ApiBearerAuth()
+  @ApiCookieAuth()
   @ApiOperation({ summary: 'Update user' })
   @ApiBody({ type: UpdateUserRequestDto })
   async updateUser(@Body() request: UpdateUserRequestDto) {


### PR DESCRIPTION
- use cookie auth in browser app scenarios
- use bearer auth in mobile/native app scenarios

close #151 