### PR TITLE
fix: allow nullable amounts in solowallet withdraw continue

### DIFF
--- a/libs/common/src/dto/solowallet.dto.ts
+++ b/libs/common/src/dto/solowallet.dto.ts
@@ -41,7 +41,6 @@ export class DepositFundsRequestDto implements DepositFundsRequest {
   @ApiProperty()
   reference: string;
 
-  @ApiProperty()
   @IsNumber()
   @Min(1)
   @ApiProperty({ example: 2 })
@@ -104,7 +103,6 @@ export class WithdrawFundsRequestDto implements WithdrawFundsRequest {
   @ApiProperty({ example: '43040650-5090-4dd4-8e93-8fd342533e7c' })
   userId: string;
 
-  @ApiProperty()
   @IsNumber()
   @Min(1)
   @ApiProperty({ example: 2 })
@@ -159,9 +157,8 @@ export class ContinueWithdrawFundsRequestDto
   @ApiProperty({ example: '4a4b4c4d-cb98-40b1-9ed2-a13006a9f670' })
   txId: string;
 
-  @ApiProperty()
+  @IsOptional()
   @IsNumber()
-  @Min(1)
   @ApiProperty({ example: 2 })
   amountFiat: number;
 

--- a/libs/common/src/types/proto/solowallet.ts
+++ b/libs/common/src/types/proto/solowallet.ts
@@ -50,7 +50,7 @@ export interface WithdrawFundsRequest {
 export interface ContinueWithdrawFundsRequest {
   userId: string;
   txId: string;
-  amountFiat: number;
+  amountFiat?: number | undefined;
   offramp?: OfframpSwapTarget | undefined;
   lightning?: Bolt11 | undefined;
   lnurlRequest?: boolean | undefined;

--- a/proto/solowallet.proto
+++ b/proto/solowallet.proto
@@ -79,7 +79,7 @@ message ContinueWithdrawFundsRequest {
 
   string tx_id = 2;
 
-  int32 amount_fiat = 3;
+  optional int32 amount_fiat = 3;
   
   optional lib.OfframpSwapTarget offramp = 4;
   


### PR DESCRIPTION
- applies in scenarios where withdrawal is going to a lightning invoice