### PR TITLE
Feat: Emit collection_for_shares event for chama deposits with shares subscription context

### DIFF
--- a/apps/chama/src/wallet/db/wallet.schema.ts
+++ b/apps/chama/src/wallet/db/wallet.schema.ts
@@ -50,6 +50,9 @@ export class ChamaWalletDocument extends AbstractDocument {
 
   @Prop({ type: String, required: true })
   paymentTracker?: string;
+
+  @Prop({ type: String, required: false })
+  context?: string;
 }
 
 export const ChamaWalletSchema =
@@ -78,6 +81,15 @@ export function toChamaWalletTx(
     updatedAt = doc.updatedAt.toString();
   }
 
+  let context = undefined;
+  if (doc.context) {
+    try {
+      context = JSON.parse(doc.context);
+    } catch (error) {
+      logger.warn(`Error parsing transaction context: ${error}`);
+    }
+  }
+
   return {
     id: doc._id,
     memberId: doc.memberId,
@@ -93,6 +105,7 @@ export function toChamaWalletTx(
     ),
     type: parseTransactionType(doc.type.toString(), logger),
     lightning: parseFmLightning(doc.lightning, logger),
+    context,
     createdAt,
     updatedAt,
   };

--- a/apps/chama/src/wallet/db/wallet.schema.ts
+++ b/apps/chama/src/wallet/db/wallet.schema.ts
@@ -105,7 +105,6 @@ export function toChamaWalletTx(
     ),
     type: parseTransactionType(doc.type.toString(), logger),
     lightning: parseFmLightning(doc.lightning, logger),
-    context,
     createdAt,
     updatedAt,
   };

--- a/apps/chama/src/wallet/wallet.service.spec.ts
+++ b/apps/chama/src/wallet/wallet.service.spec.ts
@@ -1,0 +1,180 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChamaWalletService } from './wallet.service';
+import { ChamaWalletRepository } from './db';
+import {
+  collection_for_shares,
+  FedimintContext,
+  FedimintReceiveSuccessEvent,
+  FedimintService,
+  SWAP_SERVICE_NAME,
+  TransactionStatus,
+  WalletTxContext,
+} from '@bitsacco/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ChamasService } from '../chamas/chamas.service';
+import { UsersService } from '@bitsacco/common';
+import { ChamaMessageService } from '../chamas/chamas.messaging';
+
+describe('ChamaWalletService', () => {
+  let service: ChamaWalletService;
+  let eventEmitter: EventEmitter2;
+
+  const mockWalletRepository = {
+    findOneAndUpdate: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockFedimintService = {
+    invoice: jest.fn(),
+    receive: jest.fn(),
+  };
+
+  const mockSwapGrpc = {
+    getService: jest.fn().mockReturnValue({}),
+  };
+
+  const mockChamasService = {};
+  const mockUsersService = {};
+  const mockMessengerService = {};
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChamaWalletService,
+        {
+          provide: ChamaWalletRepository,
+          useValue: mockWalletRepository,
+        },
+        {
+          provide: FedimintService,
+          useValue: mockFedimintService,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
+            on: jest.fn(),
+          },
+        },
+        {
+          provide: SWAP_SERVICE_NAME,
+          useValue: mockSwapGrpc,
+        },
+        {
+          provide: ChamasService,
+          useValue: mockChamasService,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+        {
+          provide: ChamaMessageService,
+          useValue: mockMessengerService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ChamaWalletService>(ChamaWalletService);
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2);
+  });
+
+  describe('handleSuccessfulReceive', () => {
+    it('should update transaction to COMPLETE when payment is successful', async () => {
+      // Arrange
+      const operationId = 'test-operation-id';
+      const mockTx = {
+        _id: 'tx123',
+        status: TransactionStatus.PENDING,
+      };
+
+      mockWalletRepository.findOneAndUpdate.mockResolvedValue(mockTx);
+
+      const event: FedimintReceiveSuccessEvent = {
+        context: FedimintContext.CHAMAWALLET_RECEIVE,
+        operationId,
+      };
+
+      // Act
+      await service.handleSuccessfulReceive(event);
+
+      // Assert
+      expect(mockWalletRepository.findOneAndUpdate).toHaveBeenCalledWith(
+        { paymentTracker: operationId },
+        { status: TransactionStatus.COMPLETE },
+      );
+    });
+
+    it('should emit collection_for_shares event when transaction has sharesSubscriptionTracker context', async () => {
+      // Arrange
+      const operationId = 'test-operation-id';
+      const sharesId = 'shares-subscription-id';
+      const mockTx = {
+        _id: 'tx123',
+        status: TransactionStatus.PENDING,
+        context: JSON.stringify({
+          sharesSubscriptionTracker: sharesId,
+        }),
+      };
+
+      mockWalletRepository.findOneAndUpdate.mockResolvedValue(mockTx);
+
+      const event: FedimintReceiveSuccessEvent = {
+        context: FedimintContext.CHAMAWALLET_RECEIVE,
+        operationId,
+      };
+
+      const emitSpy = jest.spyOn(eventEmitter, 'emit');
+
+      // Act
+      await service.handleSuccessfulReceive(event);
+
+      // Assert
+      expect(mockWalletRepository.findOneAndUpdate).toHaveBeenCalledWith(
+        { paymentTracker: operationId },
+        { status: TransactionStatus.COMPLETE },
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(collection_for_shares, {
+        context: WalletTxContext.COLLECTION_FOR_SHARES,
+        payload: {
+          paymentTracker: sharesId,
+          paymentStatus: TransactionStatus.COMPLETE,
+        },
+      });
+    });
+
+    it('should handle missing or invalid context gracefully', async () => {
+      // Arrange
+      const operationId = 'test-operation-id';
+      const mockTx = {
+        _id: 'tx123',
+        status: TransactionStatus.PENDING,
+        context: 'invalid-json', // This will cause JSON.parse to fail
+      };
+
+      mockWalletRepository.findOneAndUpdate.mockResolvedValue(mockTx);
+
+      const event: FedimintReceiveSuccessEvent = {
+        context: FedimintContext.CHAMAWALLET_RECEIVE,
+        operationId,
+      };
+
+      const emitSpy = jest.spyOn(eventEmitter, 'emit');
+
+      // Act - this should not throw an error
+      await service.handleSuccessfulReceive(event);
+
+      // Assert
+      expect(mockWalletRepository.findOneAndUpdate).toHaveBeenCalledWith(
+        { paymentTracker: operationId },
+        { status: TransactionStatus.COMPLETE },
+      );
+
+      // Event should not be emitted due to invalid context
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/shares/.dev.env
+++ b/apps/shares/.dev.env
@@ -3,3 +3,5 @@ NODE_ENV='development'
 SHARES_GRPC_URL='shares:4070'
 SHARES_ISSUED='10000'
 DATABASE_URL=mongodb://bs:password@mongodb:27017
+REDIS_HOST='redis'
+REDIS_PORT='6379'

--- a/apps/shares/src/main.ts
+++ b/apps/shares/src/main.ts
@@ -12,7 +12,7 @@ async function bootstrap() {
   const configService = app.get(ConfigService);
 
   const shares_url = configService.getOrThrow<string>('SHARES_GRPC_URL');
-  const shares = app.connectMicroservice<MicroserviceOptions>({
+  app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.GRPC,
     options: {
       package: 'shares',
@@ -21,6 +21,16 @@ async function bootstrap() {
       onLoadPackageDefinition: (pkg, server) => {
         new ReflectionService(pkg).addToServer(server);
       },
+    },
+  });
+
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.REDIS,
+    options: {
+      host: configService.getOrThrow<string>('REDIS_HOST'),
+      port: configService.getOrThrow<number>('REDIS_PORT'),
+      retryAttempts: 2,
+      retryDelay: 100,
     },
   });
 

--- a/apps/shares/src/shares.controller.ts
+++ b/apps/shares/src/shares.controller.ts
@@ -1,4 +1,4 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Logger } from '@nestjs/common';
 import { EventPattern, GrpcMethod } from '@nestjs/microservices';
 import {
   collection_for_shares,
@@ -18,6 +18,8 @@ import { SharesService } from './shares.service';
 @Controller()
 @SharesServiceControllerMethods()
 export class SharesController {
+  private readonly logger = new Logger(SharesController.name);
+
   constructor(private readonly sharesService: SharesService) {}
 
   @GrpcMethod()
@@ -62,6 +64,9 @@ export class SharesController {
 
   @EventPattern(collection_for_shares)
   async handleCollectionForShares(event: WalletTxEvent) {
+    this.logger.log(
+      `Received a collection_for_shares event with Context : ${event.context} and Payload : ${JSON.stringify(event.payload)}`,
+    );
     if (event.context === WalletTxContext.COLLECTION_FOR_SHARES) {
       await this.sharesService.handleWalletTxForShares(event);
     }

--- a/apps/shares/src/shares.controller.ts
+++ b/apps/shares/src/shares.controller.ts
@@ -1,7 +1,9 @@
 import { Controller } from '@nestjs/common';
-import { GrpcMethod } from '@nestjs/microservices';
+import { EventPattern, GrpcMethod } from '@nestjs/microservices';
 import {
+  collection_for_shares,
   type Empty,
+  type WalletTxEvent,
   FindSharesTxDto,
   OfferSharesDto,
   SharesServiceControllerMethods,
@@ -9,6 +11,7 @@ import {
   TransferSharesDto,
   UpdateSharesDto,
   UserSharesDto,
+  WalletTxContext,
 } from '@bitsacco/common';
 import { SharesService } from './shares.service';
 
@@ -55,5 +58,12 @@ export class SharesController {
   @GrpcMethod()
   findSharesTransaction(request: FindSharesTxDto) {
     return this.sharesService.findSharesTransaction(request);
+  }
+
+  @EventPattern(collection_for_shares)
+  async handleCollectionForShares(event: WalletTxEvent) {
+    if (event.context === WalletTxContext.COLLECTION_FOR_SHARES) {
+      await this.sharesService.handleWalletTxForShares(event);
+    }
   }
 }

--- a/apps/shares/src/shares.module.ts
+++ b/apps/shares/src/shares.module.ts
@@ -1,6 +1,14 @@
 import * as Joi from 'joi';
 import { Module } from '@nestjs/common';
-import { DatabaseModule, LoggerModule } from '@bitsacco/common';
+import {
+  CustomStore,
+  DatabaseModule,
+  EVENTS_SERVICE_BUS,
+  LoggerModule,
+} from '@bitsacco/common';
+import { CacheModule } from '@nestjs/cache-manager';
+import { redisStore } from 'cache-manager-redis-store';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { SharesController } from './shares.controller';
 import { SharesService } from './shares.service';
@@ -22,7 +30,41 @@ import {
         SHARES_GRPC_URL: Joi.string().required(),
         SHARES_ISSUED: Joi.number().required(),
         DATABASE_URL: Joi.string().required(),
+        REDIS_HOST: Joi.string().required(),
+        REDIS_PORT: Joi.number().required(),
       }),
+    }),
+    ClientsModule.registerAsync([
+      {
+        name: EVENTS_SERVICE_BUS,
+        useFactory: (configService: ConfigService) => ({
+          transport: Transport.REDIS,
+          options: {
+            host: configService.getOrThrow<string>('REDIS_HOST'),
+            port: configService.getOrThrow<number>('REDIS_PORT'),
+          },
+        }),
+        inject: [ConfigService],
+      },
+    ]),
+    CacheModule.registerAsync({
+      isGlobal: true,
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => {
+        const store = await redisStore({
+          socket: {
+            host: configService.getOrThrow<string>('REDIS_HOST'),
+            port: configService.getOrThrow<number>('REDIS_PORT'),
+          },
+          ttl: 60 * 60 * 5, // 5 hours
+        });
+
+        return {
+          store: new CustomStore(store, undefined /* TODO: inject logger */),
+          ttl: 60 * 60 * 5, // 5 hours
+        };
+      },
+      inject: [ConfigService],
     }),
     DatabaseModule,
     DatabaseModule.forFeature([
@@ -33,8 +75,8 @@ import {
   ],
   controllers: [SharesController],
   providers: [
-    SharesService,
     ConfigService,
+    SharesService,
     SharesOfferRepository,
     SharesRepository,
   ],

--- a/apps/shares/src/shares.service.spec.ts
+++ b/apps/shares/src/shares.service.spec.ts
@@ -1,0 +1,221 @@
+import { Test } from '@nestjs/testing';
+import { SharesService } from './shares.service';
+import { SharesOfferRepository, SharesRepository } from './db';
+import {
+  WalletTxContext,
+  WalletTxEvent,
+  SharesTxStatus,
+  TransactionStatus,
+} from '@bitsacco/common';
+
+describe('SharesService', () => {
+  let service: SharesService;
+  let sharesRepository: SharesRepository;
+  let sharesOfferRepository: SharesOfferRepository;
+
+  // Mock data
+  const mockSharesOffer = {
+    _id: 'offer123',
+    quantity: 100,
+    subscribedQuantity: 20,
+    availableFrom: new Date(),
+    availableTo: new Date(Date.now() + 86400000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockSharesTx = {
+    _id: 'sharesTx123',
+    userId: 'user123',
+    offerId: 'offer123',
+    quantity: 5,
+    status: SharesTxStatus.PROPOSED,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        SharesService,
+        {
+          provide: SharesRepository,
+          useValue: {
+            create: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            findOneAndUpdate: jest.fn(),
+          },
+        },
+        {
+          provide: SharesOfferRepository,
+          useValue: {
+            create: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+            findOneAndUpdate: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SharesService>(SharesService);
+    sharesRepository = module.get<SharesRepository>(SharesRepository);
+    sharesOfferRepository = module.get<SharesOfferRepository>(
+      SharesOfferRepository,
+    );
+
+    // Override logger to prevent console noise during tests
+    jest.spyOn(service, 'logger', 'get').mockReturnValue({
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    } as any);
+
+    // Mock the updateShares method
+    jest.spyOn(service, 'updateShares').mockResolvedValue(null);
+
+    // Default mock implementations
+    jest.spyOn(sharesRepository, 'find').mockResolvedValue([]);
+    jest.spyOn(sharesOfferRepository, 'find').mockResolvedValue([]);
+    jest.spyOn(sharesRepository, 'findOne').mockResolvedValue(null);
+    jest.spyOn(sharesOfferRepository, 'findOne').mockResolvedValue(null);
+  });
+
+  describe('handleWalletTxForShares', () => {
+    it('should update shares transaction to COMPLETE when payment is completed', async () => {
+      // Arrange
+      const walletTxEvent: WalletTxEvent = {
+        context: WalletTxContext.COLLECTION_FOR_SHARES,
+        payload: {
+          paymentTracker: 'sharesTx123',
+          paymentStatus: TransactionStatus.COMPLETE,
+        },
+      };
+
+      jest.spyOn(sharesRepository, 'findOne').mockResolvedValue(mockSharesTx);
+      jest
+        .spyOn(sharesOfferRepository, 'findOne')
+        .mockResolvedValue(mockSharesOffer);
+
+      // Act
+      await service.handleWalletTxForShares(walletTxEvent);
+
+      // Assert
+      expect(sharesRepository.findOne).toHaveBeenCalledWith({
+        _id: 'sharesTx123',
+      });
+      expect(service.updateShares).toHaveBeenCalledWith({
+        sharesId: 'sharesTx123',
+        updates: {
+          status: SharesTxStatus.COMPLETE,
+        },
+      });
+    });
+
+    it('should update shares transaction to PROCESSING when payment is processing', async () => {
+      // Arrange
+      const walletTxEvent: WalletTxEvent = {
+        context: WalletTxContext.COLLECTION_FOR_SHARES,
+        payload: {
+          paymentTracker: 'sharesTx123',
+          paymentStatus: TransactionStatus.PROCESSING,
+        },
+      };
+
+      jest.spyOn(sharesRepository, 'findOne').mockResolvedValue(mockSharesTx);
+
+      // Act
+      await service.handleWalletTxForShares(walletTxEvent);
+
+      // Assert
+      expect(sharesRepository.findOne).toHaveBeenCalledWith({
+        _id: 'sharesTx123',
+      });
+      expect(service.updateShares).toHaveBeenCalledWith({
+        sharesId: 'sharesTx123',
+        updates: {
+          status: SharesTxStatus.PROCESSING,
+        },
+      });
+    });
+
+    it('should update shares transaction to FAILED when payment fails', async () => {
+      // Arrange
+      const walletTxEvent: WalletTxEvent = {
+        context: WalletTxContext.COLLECTION_FOR_SHARES,
+        payload: {
+          paymentTracker: 'sharesTx123',
+          paymentStatus: TransactionStatus.FAILED,
+        },
+      };
+
+      jest.spyOn(sharesRepository, 'findOne').mockResolvedValue(mockSharesTx);
+
+      // Act
+      await service.handleWalletTxForShares(walletTxEvent);
+
+      // Assert
+      expect(sharesRepository.findOne).toHaveBeenCalledWith({
+        _id: 'sharesTx123',
+      });
+      expect(service.updateShares).toHaveBeenCalledWith({
+        sharesId: 'sharesTx123',
+        updates: {
+          status: SharesTxStatus.FAILED,
+        },
+      });
+    });
+
+    it('should handle wallet tx error properly', async () => {
+      // Arrange
+      const walletTxEvent: WalletTxEvent = {
+        context: WalletTxContext.COLLECTION_FOR_SHARES,
+        payload: {
+          paymentTracker: 'sharesTx123',
+          paymentStatus: TransactionStatus.FAILED,
+        },
+        error: 'Payment processing error',
+      };
+
+      jest.spyOn(sharesRepository, 'findOne').mockResolvedValue(mockSharesTx);
+
+      // Act
+      await service.handleWalletTxForShares(walletTxEvent);
+
+      // Assert
+      expect(sharesRepository.findOne).toHaveBeenCalledWith({
+        _id: 'sharesTx123',
+      });
+      expect(service.updateShares).toHaveBeenCalledWith({
+        sharesId: 'sharesTx123',
+        updates: {
+          status: SharesTxStatus.FAILED,
+        },
+      });
+    });
+
+    it('should do nothing if shares transaction is not found', async () => {
+      // Arrange
+      const walletTxEvent: WalletTxEvent = {
+        context: WalletTxContext.COLLECTION_FOR_SHARES,
+        payload: {
+          paymentTracker: 'nonexistent',
+          paymentStatus: TransactionStatus.COMPLETE,
+        },
+      };
+
+      jest.spyOn(sharesRepository, 'findOne').mockResolvedValue(null);
+
+      // Act
+      await service.handleWalletTxForShares(walletTxEvent);
+
+      // Assert
+      expect(sharesRepository.findOne).toHaveBeenCalledWith({
+        _id: 'nonexistent',
+      });
+      expect(service.updateShares).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/shares/src/shares.service.ts
+++ b/apps/shares/src/shares.service.ts
@@ -195,8 +195,6 @@ export class SharesService {
       await this.shares.find({ userId, ...STATUS_FILTER }, { createdAt: -1 })
     ).map(toSharesTx, pagination);
 
-    this.logger.log(`Shares: ${JSON.stringify(shares)}`);
-
     const shareHoldings = shares
       .filter((share) => {
         return (
@@ -207,8 +205,6 @@ export class SharesService {
       .reduce((sum, share) => sum + share.quantity, 0);
 
     const txShares = await this.getPaginatedShareTx({ userId }, pagination);
-
-    this.logger.log(`Tx shares: ${JSON.stringify(txShares)}`);
 
     const offers = await this.getSharesOffers();
 
@@ -238,8 +234,6 @@ export class SharesService {
     sharesId,
   }: FindSharesTxDto): Promise<SharesTx> {
     const shares = toSharesTx(await this.shares.findOne({ _id: sharesId }));
-
-    this.logger.log(`shares: ${JSON.stringify(shares)}`);
 
     if (!shares) {
       throw new Error('Shares transaction not found');

--- a/apps/shares/src/shares.service.ts
+++ b/apps/shares/src/shares.service.ts
@@ -292,8 +292,11 @@ export class SharesService {
     };
   }
 
-  async handleWalletTxForShares({ payload, error }: WalletTxEvent) {
+  async handleWalletTxForShares({ context, payload, error }: WalletTxEvent) {
     const { paymentTracker, paymentStatus } = payload;
+    this.logger.log(
+      `Received swap status change - context: ${context} - sharesTransactionTracker : ${paymentTracker} - status : ${paymentStatus}`,
+    );
 
     error &&
       this.logger.error(

--- a/libs/common/src/dto/chamawallet.dto.ts
+++ b/libs/common/src/dto/chamawallet.dto.ts
@@ -25,6 +25,7 @@ import {
   type OnrampSwapSource,
   type ChamaDepositRequest,
   type ChamaTxMetaRequest,
+  type ChamaTxContext,
 } from '../types';
 import {
   Bolt11InvoiceDto,
@@ -61,6 +62,13 @@ const PaginationDecorator = () => {
   );
 };
 
+class ChamaTxContextDto implements ChamaTxContext {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  sharesSubscriptionTracker?: string;
+}
+
 class ChamaBaseDto {
   @PaginationDecorator()
   pagination?: PaginatedRequest;
@@ -91,6 +99,12 @@ export class ChamaDepositDto
   @Type(() => OnrampSwapSourceDto)
   @ApiProperty({ type: OnrampSwapSourceDto })
   onramp?: OnrampSwapSource;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChamaTxContextDto)
+  @ApiProperty({ type: ChamaTxContextDto })
+  context?: ChamaTxContext;
 }
 
 export class ChamaContinueDepositDto

--- a/libs/common/src/dto/chamawallet.dto.ts
+++ b/libs/common/src/dto/chamawallet.dto.ts
@@ -66,6 +66,7 @@ class ChamaTxContextDto implements ChamaTxContext {
   @IsOptional()
   @IsString()
   @IsNotEmpty()
+  @ApiProperty({ required: false })
   sharesSubscriptionTracker?: string;
 }
 

--- a/libs/common/src/events/names.ts
+++ b/libs/common/src/events/names.ts
@@ -3,3 +3,5 @@ export const swap_status_change = 'swap.status.change';
 
 export const fedimint_receive_success = 'fedimint.receive.success';
 export const fedimint_receive_failure = 'fedimint.receive.failure';
+
+export const collection_for_shares = 'collection.for.shares';

--- a/libs/common/src/events/types.ts
+++ b/libs/common/src/events/types.ts
@@ -34,3 +34,18 @@ export interface SwapStatusChangeEvent {
   payload: SwapStatusChangePayload;
   error?: string;
 }
+
+export enum WalletTxContext {
+  COLLECTION_FOR_SHARES,
+}
+
+interface WalletTxEventPayload {
+  paymentTracker: string;
+  paymentStatus: TransactionStatus;
+}
+
+export interface WalletTxEvent {
+  context: WalletTxContext;
+  payload: WalletTxEventPayload;
+  error?: string;
+}

--- a/libs/common/src/types/proto/chamawallet.ts
+++ b/libs/common/src/types/proto/chamawallet.ts
@@ -55,12 +55,17 @@ export interface ChamaTxReview {
   review: Review;
 }
 
+export interface ChamaTxContext {
+  sharesSubscriptionTracker?: string | undefined;
+}
+
 export interface ChamaDepositRequest {
   memberId: string;
   chamaId: string;
   amountFiat: number;
   reference?: string | undefined;
   onramp?: OnrampSwapSource | undefined;
+  context?: ChamaTxContext | undefined;
   pagination?: PaginatedRequest | undefined;
 }
 

--- a/proto/chamawallet.proto
+++ b/proto/chamawallet.proto
@@ -50,6 +50,8 @@ message ChamaWalletTx {
   string createdAt = 11;
 
   optional string updatedAt = 12;
+  
+  optional ChamaTxContext context = 13;
 }
 
 enum ChamaTxStatus {
@@ -71,6 +73,10 @@ enum Review {
   APPROVE = 1;
 }
 
+message ChamaTxContext {
+  optional string shares_subscription_tracker = 2;
+}
+
 message ChamaDepositRequest {
   string member_id = 1;
 
@@ -83,7 +89,9 @@ message ChamaDepositRequest {
   optional lib.OnrampSwapSource onramp = 5;
 
   // Add more optional funding sources, like direct lightning deposit
-  reserved 6,7,8,9,10;
+  reserved 6,7,8,9;
+
+  optional ChamaTxContext context = 10;
 
   optional lib.PaginatedRequest pagination = 11;
 }


### PR DESCRIPTION
## Summary
- Add context field to chama wallet schema to store sharesSubscriptionTracker
- Update proto file to include context in ChamaWalletTx type
- Implement event emission in handleSuccessfulReceive for completed chama deposits with shares subscription context 
- Add shares service handler for collection_for_shares events
- Add comprehensive tests for both event emission and handling

## Test plan
- Added unit tests for ChamaWalletService to verify event emission behavior
- Fixed and updated SharesService tests to verify event handling
- Manually tested by verifying that events are correctly emitted when deposits with subscription context complete