### PR TITLE
feat: encode chama details

### DIFF
--- a/apps/chama/src/wallet/wallet.service.ts
+++ b/apps/chama/src/wallet/wallet.service.ts
@@ -370,7 +370,7 @@ export class ChamaWalletService {
           id: withdrawal.memberId,
         });
 
-        this.messenger.sendChamaWithdrawalRequests(chama, admins, withdrawal, {
+        this.messenger.sendChamaWithdrawalRequests(chama, withdrawal.id, admins, {
           name: beneficiary.profile?.name,
           phoneNumber: beneficiary.phone?.number,
           // nostrNpub: beneficiary.nostr?.npub,

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,6 @@ services:
       - ./apps/api/.dev.env
     ports:
       - '4000:4000'
-      - '3001:3001'  # WebSocket port
     volumes:
       - .:/usr/src/app
   auth:


### PR DESCRIPTION
when sending chama withdrawal links, we can encode simple data points i.e. `chamaId` and `chamaTxId` only. The client does the heavy lifting of fetching full chama and transaction data